### PR TITLE
fix: zatsudan in english, use auto.tfvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ override.tf.json
 # no need lock file on this repo
 .terraform.lock.hcl
 
+# no need .auto.tfvars on this repo because use only test for local
+*.auto.tfvars
+

--- a/jokes/zatsudan/README.md
+++ b/jokes/zatsudan/README.md
@@ -23,3 +23,22 @@ terraform taint random_shuffle.selector
 
 - https://www.terraform.io/docs/cli/commands/taint.html
 
+## one more thing
+
+好きに遊べるように test.auto.tfvars のようなファイルを作ってみましょう。
+
+```
+cat test.auto.tfvars
+selection = [
+    "た:旅",
+    "の:乗り物",
+    "し:仕事、趣味",
+    "く:国(故郷）",
+    "は:はやり",
+    "な:長生き、健康",
+    "す:スポーツ",
+    "こ:子供",
+    "つ:通信（ニュース・社会問題等）",
+]
+```
+

--- a/jokes/zatsudan/main.tf
+++ b/jokes/zatsudan/main.tf
@@ -1,19 +1,22 @@
-locals {
-  selection = [
-    "た:旅",
-    "の:乗り物",
-    "し:仕事、趣味",
-    "く:国(故郷）",
-    "は:はやり",
-    "な:長生き、健康",
-    "す:スポーツ",
-    "こ:子供",
-    "つ:通信（ニュース・社会問題等）",
+variable "selection" {
+  description = "tWhat shall we talk about?"
+
+  type    = list(string)
+  default = [
+    "favorite music ?",
+    "favorite AWS service is ?",
+    "dog or cat ?",
   ]
+
+  validation {
+    condition     = length(var.selection) > 2
+    error_message = "It needs to be a random value, so make it more than one list."
+  }
+
 }
 
 resource "random_shuffle" "selector" {
-  input        = local.selection
+  input        = var.selection
   result_count = 1
 }
 


### PR DESCRIPTION
ローカルでテストしてもらう時に、自由に入力できたほうがいいので、local から var に変更。

興味をひけるように、デフォルトは英語表記にして、追加で日本語にして遊べるようにみせる。

validation を使ってみたかったのでいれてみた。 test.auto.tfvars で検証できる。